### PR TITLE
Fix Fix Strange factor and Core storage control modes

### DIFF
--- a/custom_components/fronius_modbus/froniusmodbusclient.py
+++ b/custom_components/fronius_modbus/froniusmodbusclient.py
@@ -635,37 +635,43 @@ class FroniusModbusClient(ExtModbusClient):
         await self.set_charge_rate(charge_rate)
 
     async def set_grid_charge_power(self, value):
+        """value is in W from HA, store percent internally."""
         if self.storage_extended_control_mode == 4:
             await self.set_discharge_rate_w(value * -1)
-            self.data['grid_charge_power'] = value
+            percent = (value / self.max_charge_rate_w) * 100 if self.max_charge_rate_w else 0
+            self.data['grid_charge_power'] = percent
         else:
             return
 
     async def set_grid_discharge_power(self, value):
+        """value is in W from HA, store percent internally."""
         if self.storage_extended_control_mode == 5:
             await self.set_charge_rate_w(value * -1)
-            self.data['grid_discharge_power'] = value
+            percent = (value / self.max_discharge_rate_w) * 100 if self.max_discharge_rate_w else 0
+            self.data['grid_discharge_power'] = percent
         else:
             return
         
     async def set_charge_limit(self, value):
-        if self.storage_extended_control_mode in [1,3,6]:
-            # only change when charge limit is used
+        """value is in W from HA, store percent internally."""
+        if self.storage_extended_control_mode in [1, 3, 6]:
             await self.set_charge_rate_w(value)
-            self.data['charge_limit'] = value
-        elif self.storage_extended_control_mode in [4,5,7]:
+            percent = (value / self.max_charge_rate_w) * 100 if self.max_charge_rate_w else 0
+            self.data['charge_limit'] = percent
+        elif self.storage_extended_control_mode in [4, 5, 7]:
             return
-        elif self.storage_extended_control_mode in [0,2]:
+        elif self.storage_extended_control_mode in [0, 2]:
             return
 
     async def set_discharge_limit(self, value):
-        if self.storage_extended_control_mode in [2,3,7]:
-            # only change when discharge limit is used
+        """value is in W from HA, store percent internally."""
+        if self.storage_extended_control_mode in [2, 3, 7]:
             await self.set_discharge_rate_w(value)
-            self.data['discharge_limit'] = value
-        elif self.storage_extended_control_mode in [4,5,6]:
+            percent = (value / self.max_discharge_rate_w) * 100 if self.max_discharge_rate_w else 0
+            self.data['discharge_limit'] = percent
+        elif self.storage_extended_control_mode in [1, 4, 5, 6]:
             return
-        elif self.storage_extended_control_mode in [0,1]:
+        elif self.storage_extended_control_mode in [0]:
             return
 
     async def set_charge_rate(self, charge_rate):

--- a/custom_components/fronius_modbus/number.py
+++ b/custom_components/fronius_modbus/number.py
@@ -73,7 +73,12 @@ class FroniusModbusNumber(FroniusModbusBaseEntity, NumberEntity):
     def state(self):
         """Return the state of the sensor."""
         if self._key in self._hub.data:
-            return self._hub.data[self._key]
+            if self._key in ['grid_discharge_power', 'discharge_limit']:
+                return round(self._hub.data[self._key] / 100.0 * self._hub.max_discharge_rate_w, 0)
+            elif self._key in ['grid_charge_power', 'charge_limit']:
+                return round(self._hub.data[self._key] / 100.0 * self._hub.max_charge_rate_w, 0)
+            else:
+                return self._hub.data[self._key]
         return None
 
     async def async_set_native_value(self, value: float) -> None:


### PR DESCRIPTION
#28 Fix Strange factor for
I've been digging into this issue and think I have tracked down the root cause. Fronius expects charge and discharge setpoints in percent (as defined by SunSpec), but the integration currently treats the Home Assistant number entities as watts. The value entered in watts is converted to percent, stored internally as percent, and then shown back in the UI as if it were watts.

Ive made an attempt to separate the two directions properly so that watts are always shown in Home Assistant, while percent values are still written correctly to the inverter.

#26 Fix Core storage control mode 
The Storage control values was swapped in the code.