### PR TITLE
Fix meter discovery for fronius 'watt node' model meter

### DIFF
--- a/custom_components/fronius_modbus/froniusmodbusclient.py
+++ b/custom_components/fronius_modbus/froniusmodbusclient.py
@@ -574,7 +574,7 @@ class FroniusModbusClient(ExtModbusClient):
 
             manufacturer = str(self.data.get(prefix + "manufacturer") or "").strip()
             model = str(self.data.get(prefix + "model") or "").strip()
-            if manufacturer == "Fronius" and "meter" in model.lower():
+            if manufacturer == "Fronius" and ("meter" in model.lower() or "wattnode" in model.lower()):
                 discovered_meter_unit_ids.append(unit_id)
 
         self._meter_unit_ids = discovered_meter_unit_ids

--- a/custom_components/fronius_modbus/froniuswebclient.py
+++ b/custom_components/fronius_modbus/froniuswebclient.py
@@ -174,7 +174,7 @@ def _parse_power_meter_info(
 
         if rtu_addr <= 0:
             continue
-        if manufacturer != "Fronius" or not model or "meter" not in model.lower():
+        if manufacturer != "Fronius" or not model or not ("meter" in model.lower() or "wattnode" in model.lower()):
             continue
 
         label = (_clean_text(attributes.get("label")) or "").lower()


### PR DESCRIPTION
Fronius 'WattNode' meter not being discovered as it does not use the word 'meter' in the model name. Add 'WattNode' to filter. 