### PR TITLE
fix registry collisions for multiple entries

### DIFF
--- a/custom_components/fronius_modbus/__init__.py
+++ b/custom_components/fronius_modbus/__init__.py
@@ -75,6 +75,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HubConfigEntry) -> bool:
 
     await entry.runtime_data.init_data(config_entry=entry)
     await migrations.async_migrate_v019_mppt_statistics(hass, entry, entry.runtime_data)
+    await migrations.async_migrate_name_based_unique_ids(hass, entry, entry.runtime_data)
     await migrations.async_remove_unexpected_entities(hass, entry, entry.runtime_data)
     await migrations.async_remove_legacy_devices(hass, entry)
     await migrations.async_sync_reconfigure_issue(

--- a/custom_components/fronius_modbus/config_flow.py
+++ b/custom_components/fronius_modbus/config_flow.py
@@ -131,6 +131,12 @@ def _entry_payload(data: dict[str, Any], *, reconfigure_required: bool) -> dict[
     return payload
 
 
+def _entry_title(data: dict[str, Any]) -> str:
+    host = str(data.get(CONF_HOST, "")).strip()
+    name = str(data.get(CONF_NAME, DEFAULT_NAME)).strip() or DEFAULT_NAME
+    return f"{name} {host}" if host else name
+
+
 def entry_defaults(entry: config_entries.ConfigEntry) -> dict[str, Any]:
     defaults = {**entry.data, **entry.options}
     try:
@@ -338,7 +344,7 @@ async def _validate_input(
     if not any(model.startswith(supported_model) for supported_model in SUPPORTED_MODELS):
         _LOGGER.warning("Untested model %s", model)
 
-    return {"title": data[CONF_NAME]}
+    return {"title": _entry_title(data)}
 
 
 async def async_update_entry_from_input(
@@ -361,7 +367,7 @@ async def async_update_entry_from_input(
         entry,
         data=new_data,
         options=new_options,
-        title=validated_input[CONF_NAME],
+        title=_entry_title(validated_input),
     )
     if previous_host and previous_host != validated_input[CONF_HOST]:
         await _async_delete_token(hass, previous_host)
@@ -477,7 +483,7 @@ class ConfigFlow(TokenFlowMixin, config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
     VERSION = 1
-    MINOR_VERSION = 8
+    MINOR_VERSION = 9
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def __init__(self) -> None:

--- a/custom_components/fronius_modbus/hub.py
+++ b/custom_components/fronius_modbus/hub.py
@@ -127,6 +127,10 @@ class Hub:
 
     PYMODBUS_VERSION = '3.11.2'
 
+    @staticmethod
+    def _normalize_instance_key(value: str) -> str:
+        return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_") or "fronius"
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -149,7 +153,7 @@ class Hub:
         self._port = port
         self._inverter_unit_id = inverter_unit_id
         self._meter_unit_ids = list(meter_unit_ids)
-        self._entity_prefix = f'{ENTITY_PREFIX}_{name.lower()}_'
+        self._fallback_instance_key = self._normalize_instance_key(host)
         self._config_entry: ConfigEntry | None = None
         self._auto_enable_modbus = auto_enable_modbus
         self._restrict_modbus_to_this_ip = restrict_modbus_to_this_ip
@@ -867,7 +871,7 @@ class Hub:
     @property 
     def device_info_storage(self) -> dict:
         return {
-            "identifiers": {(DOMAIN, f'{self._name}_battery_storage')},
+            "identifiers": {(DOMAIN, f'{self.instance_key}_battery_storage')},
             "name": f'{self._client.data.get('s_model')}',
             "manufacturer": self._client.data.get('s_manufacturer'),
             "model": self._client.data.get('s_model'),
@@ -877,7 +881,7 @@ class Hub:
     @property 
     def device_info_inverter(self) -> dict:
         return {
-            "identifiers": {(DOMAIN, f'{self._name}_inverter')},
+            "identifiers": {(DOMAIN, f'{self.instance_key}_inverter')},
             "name": f'Fronius {self._client.data.get('i_model')}',
             "manufacturer": self._client.data.get('i_manufacturer'),
             "model": self._client.data.get('i_model'),
@@ -892,7 +896,7 @@ class Hub:
         except ValueError:
             meter_position = 1
         return {
-            "identifiers": {(DOMAIN, f'{self._name}_meter_{unit_id}')},
+            "identifiers": {(DOMAIN, f'{self.instance_key}_meter_{unit_id}')},
             "name": f'Fronius {self._client.data.get(f"{prefix}model")} Meter {meter_position}',
             "manufacturer": self._client.data.get(f"{prefix}manufacturer"),
             "model": self._client.data.get(f"{prefix}model"),
@@ -906,9 +910,16 @@ class Hub:
         return self._id
 
     @property
+    def instance_key(self) -> str:
+        """Stable per-entry key for entity and device registry identity."""
+        if self._config_entry is not None:
+            return self._normalize_instance_key(self._config_entry.entry_id)
+        return self._fallback_instance_key
+
+    @property
     def entity_prefix(self) -> str:
         """Entity prefix for hub."""
-        return self._entity_prefix
+        return f"{ENTITY_PREFIX}_{self.instance_key}"
 
 
 

--- a/custom_components/fronius_modbus/migrations.py
+++ b/custom_components/fronius_modbus/migrations.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
@@ -19,6 +19,7 @@ from .const import (
     CONF_METER_UNIT_IDS,
     CONF_RECONFIGURE_REQUIRED,
     DOMAIN,
+    ENTITY_PREFIX,
     INVERTER_API_BUTTON_TYPES,
     INVERTER_API_SWITCH_TYPES,
     INVERTER_NUMBER_TYPES,
@@ -45,7 +46,7 @@ _TRANSLATIONS_DIR = Path(__file__).resolve().parent / "translations"
 _TRANSLATION_CACHE: dict[str, dict] = {}
 
 _TARGET_VERSION = 1
-_TARGET_MINOR_VERSION = 8
+_TARGET_MINOR_VERSION = 9
 
 _LEGACY_METER_DEVICE_RE = re.compile(r".*_meter\d+")
 _V019_MPPT_UNIQUE_ID_MAPPINGS = (
@@ -105,6 +106,21 @@ def _legacy_meter_device_needs_removal(device) -> bool:
 
 def _entity_unique_id(runtime_data: hub.Hub, key: str) -> str:
     return f"{runtime_data.entity_prefix}_{key}"
+
+
+def _legacy_entity_unique_id(entry: ConfigEntry, key: str) -> str:
+    name = str(_entry_value(entry, CONF_NAME, "Fronius")).lower()
+    return f"{ENTITY_PREFIX}_{name}__{key}"
+
+
+def _entry_instance_key(entry: ConfigEntry) -> str:
+    return hub.Hub._normalize_instance_key(entry.entry_id)
+
+
+def _updated_entry_title(entry: ConfigEntry) -> str:
+    name = str(_entry_value(entry, CONF_NAME, "Fronius")).strip() or "Fronius"
+    host = str(_entry_value(entry, CONF_HOST, "")).strip()
+    return f"{name} {host}" if host else name
 
 
 def _definition_keys(definitions) -> list[str]:
@@ -291,6 +307,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             options=new_options,
             version=_TARGET_VERSION,
             minor_version=_TARGET_MINOR_VERSION,
+            title=_updated_entry_title(entry),
         )
 
     return True
@@ -395,6 +412,47 @@ async def async_migrate_v019_mppt_statistics(
             "Migrated v0.1.9 MPPT entity %s -> %s to preserve statistics/history",
             old_entity_id,
             new_entity_id,
+        )
+
+
+async def async_migrate_name_based_unique_ids(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    runtime_data: hub.Hub,
+) -> None:
+    """Move old name-based unique ids to stable per-entry ids."""
+    registry = er.async_get(hass)
+    entity_entries = _entity_entries_for_config_entry(registry, entry)
+    current_unique_ids = {candidate.unique_id or "" for candidate in entity_entries}
+    expected_unique_ids = _expected_entity_unique_ids(runtime_data)
+    migrated = 0
+
+    for new_unique_id in expected_unique_ids:
+        key = new_unique_id.removeprefix(f"{runtime_data.entity_prefix}_")
+        if key == new_unique_id:
+            continue
+
+        old_unique_id = _legacy_entity_unique_id(entry, key)
+        if old_unique_id not in current_unique_ids or new_unique_id in current_unique_ids:
+            continue
+
+        entity_entry = next(
+            (candidate for candidate in entity_entries if (candidate.unique_id or "") == old_unique_id),
+            None,
+        )
+        if entity_entry is None:
+            continue
+
+        registry.async_update_entity(entity_entry.entity_id, new_unique_id=new_unique_id)
+        current_unique_ids.discard(old_unique_id)
+        current_unique_ids.add(new_unique_id)
+        migrated += 1
+
+    if migrated:
+        _LOGGER.info(
+            "Migrated %s entities from name-based unique ids to per-entry ids for %s",
+            migrated,
+            _entry_instance_key(entry),
         )
 
 


### PR DESCRIPTION
- move entity and device registry identity from the shared display name to a stable per-config-entry key so multiple inverter connections no longer collapse onto the first entry
- migrate existing name-based entity unique IDs to the new per-entry namespace and update entry titles to include the host for easier multi-system setup
- bump the config entry minor version so existing installs pick up the registry migration on reload