### PR TITLE
Add support for Export to Grid Soft Limit Control 

### DIFF
--- a/custom_components/fronius_modbus/__init__.py
+++ b/custom_components/fronius_modbus/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from . import hub, migrations
 from .const import (
     API_USERNAME,
+    TECHNICIAN_USERNAME,
     CONF_INVERTER_UNIT_ID,
     CONF_RESTRICT_MODBUS_TO_THIS_IP,
     DEFAULT_INVERTER_UNIT_ID,
@@ -59,6 +60,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: HubConfigEntry) -> bool:
     api_token = await migrations.async_prepare_entry_token(hass, entry, host)
     await migrations.async_sync_reconfigure_issue(hass, entry, has_token=api_token is not None)
 
+    from .token_store import async_get_token_store
+    tech_token = await async_get_token_store(hass).async_load_token(host, TECHNICIAN_USERNAME)
+    _LOGGER.debug("Technician token for %s: %s", host, "found" if tech_token else "not found")
+
     entry.runtime_data = hub.Hub(
         hass=hass,
         name=name,
@@ -69,6 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HubConfigEntry) -> bool:
         scan_interval=scan_interval,
         api_username=API_USERNAME if api_token else None,
         api_token=api_token,
+        tech_token=tech_token,
         auto_enable_modbus=False,
         restrict_modbus_to_this_ip=restrict_modbus_to_this_ip,
     )

--- a/custom_components/fronius_modbus/config_flow.py
+++ b/custom_components/fronius_modbus/config_flow.py
@@ -27,6 +27,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     API_USERNAME,
+    TECHNICIAN_USERNAME,
     SUPPORTED_MANUFACTURERS,
     SUPPORTED_MODELS,
 )
@@ -175,7 +176,13 @@ def _build_password_schema() -> vol.Schema:
                     type=TextSelectorType.PASSWORD,
                     autocomplete="current-password",
                 )
-            )
+            ),
+            vol.Optional("technician_password", default=""): TextSelector(
+                TextSelectorConfig(
+                    type=TextSelectorType.PASSWORD,
+                    autocomplete="current-password",
+                )
+            ),
         }
     )
 
@@ -260,6 +267,7 @@ async def _async_mint_token(
     hass: HomeAssistant,
     host: str,
     password: str,
+    username: str = API_USERNAME,
 ) -> dict[str, str]:
     password = str(password).strip()
     if password == "":
@@ -269,7 +277,7 @@ async def _async_mint_token(
         token = await hass.async_add_executor_job(
             mint_token,
             host,
-            API_USERNAME,
+            username,
             password,
         )
     except Exception as err:
@@ -465,6 +473,23 @@ class TokenFlowMixin:
                     user_input.get(CONF_API_PASSWORD, ""),
                 )
                 await _async_save_token(self.hass, state.settings[CONF_HOST], token)
+                tech_password = str(user_input.get("technician_password", "")).strip()
+                if tech_password:
+                    try:
+                        tech_token = await _async_mint_token(
+                            self.hass,
+                            state.settings[CONF_HOST],
+                            tech_password,
+                            username=TECHNICIAN_USERNAME,
+                        )
+                        await async_get_token_store(self.hass).async_save_token(
+                            state.settings[CONF_HOST],
+                            realm=tech_token["realm"],
+                            token=tech_token["token"],
+                            user=TECHNICIAN_USERNAME,
+                        )
+                    except Exception:
+                        _LOGGER.warning("Failed to store technician token, export limit control will be unavailable")
                 info = await _validate_input(
                     self.hass,
                     state.settings,

--- a/custom_components/fronius_modbus/const.py
+++ b/custom_components/fronius_modbus/const.py
@@ -28,6 +28,7 @@ DEFAULT_METER_UNIT_IDS = [DEFAULT_METER_UNIT_ID]
 DEFAULT_AUTO_ENABLE_MODBUS = True
 DEFAULT_RESTRICT_MODBUS_TO_THIS_IP = False
 API_USERNAME = "customer"
+TECHNICIAN_USERNAME = "technician"
 CONF_RECONFIGURE_REQUIRED = "_reconfigure_required"
 MIGRATION_RECONFIGURE_ISSUE_ID_PREFIX = "legacy_modbus_only_reconfigure_"
 SOLAR_API_LOW_FIRMWARE_ISSUE_ID_PREFIX = "solar_api_low_firmware_"
@@ -94,6 +95,10 @@ INVERTER_NUMBER_TYPES = [
     ['power_factor', 'power_factor', {'min': -1, 'max': 1, 'step': 0.001, 'mode':'box', 'unit': None}],
 ]
 
+INVERTER_WEB_NUMBER_TYPES = [
+    ['export_soft_limit', 'export_soft_limit', {'min': 0, 'max': 15000, 'step': 10, 'mode': 'box', 'unit': 'W'}],
+]
+
 INVERTER_SELECT_TYPES = [
     ['ac_limit_enable', 'ac_limit_enable', {0: 'Disabled', 1: 'Enabled'}],
     ['power_factor_enable', 'power_factor_enable', {0: 'Disabled', 1: 'Enabled'}],
@@ -142,6 +147,7 @@ INVERTER_SENSOR_TYPES = {
 
 INVERTER_WEB_SENSOR_TYPES = {
     'inverter_temperature': ['inverter_temperature', 'inverter_temperature', SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, '°C', 'mdi:thermometer', None],
+    'export_soft_limit': ['export_soft_limit', 'export_soft_limit', SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT, 'W', 'mdi:transmission-tower-export', None],
     'api_modbus_mode': ['api_modbus_mode', 'api_modbus_mode', None, None, None, None, EntityCategory.DIAGNOSTIC],
     'api_modbus_control': ['api_modbus_control', 'api_modbus_control', None, None, None, None, EntityCategory.DIAGNOSTIC],
     'api_modbus_sunspec_mode': ['api_modbus_sunspec_mode', 'api_modbus_sunspec_mode', None, None, None, None, EntityCategory.DIAGNOSTIC],

--- a/custom_components/fronius_modbus/froniuswebclient.py
+++ b/custom_components/fronius_modbus/froniuswebclient.py
@@ -376,7 +376,7 @@ class FroniusWebClient:
         timeout: float = 4.0,
     ) -> None:
         self._host = host
-        self._username = API_USERNAME
+        self._username = username if username is not None else API_USERNAME
         self._password = password
         self._timeout = timeout
         self._auth = XHeaderDigestAuth(
@@ -595,3 +595,21 @@ class FroniusWebClient:
             "HYB_BM_CHARGEFROMAC": bool(charge_from_ac),
         }
         return self._post_ok("/api/config/batteries", payload)
+
+    def get_export_limit_config(self) -> dict[str, Any]:
+        """Read current Export Limit Control configuration from the inverter."""
+        try:
+            return self._get_json("/api/config/limit_settings/powerLimits")
+        except requests.HTTPError:
+            return {}
+
+    def set_export_soft_limit(self, power_w: int) -> bool:
+        """Set Export Limit Control (Soft Limit) in watts.
+
+        Reads the current config, patches only the softLimit fields, and writes back.
+        Mirrors read_export_limit.py: only modifies softLimit, leaves everything else unchanged.
+        """
+        config = self._get_json("/api/config/limit_settings/powerLimits")
+        config["exportLimits"]["activePower"]["softLimit"]["enabled"] = True
+        config["exportLimits"]["activePower"]["softLimit"]["powerLimit"] = int(power_w)
+        return self._post_ok("/api/config/limit_settings/powerLimits", config)

--- a/custom_components/fronius_modbus/hub.py
+++ b/custom_components/fronius_modbus/hub.py
@@ -55,6 +55,7 @@ WEB_API_DATA_KEYS = (
     "api_backup_reserved",
     "api_charge_from_ac",
     "api_charge_from_grid",
+    "export_soft_limit",
 )
 
 BATTERY_WRITE_MODBUS_RECOVERY_SECONDS = 30.0
@@ -143,6 +144,7 @@ class Hub:
         api_username: str | None = None,
         api_password: str | None = None,
         api_token: dict[str, str] | None = None,
+        tech_token: dict[str, str] | None = None,
         auto_enable_modbus: bool = True,
         restrict_modbus_to_this_ip: bool = False,
     ) -> None:
@@ -158,6 +160,7 @@ class Hub:
         self._auto_enable_modbus = auto_enable_modbus
         self._restrict_modbus_to_this_ip = restrict_modbus_to_this_ip
         self._webclient: FroniusWebClient | None = None
+        self._tech_webclient: FroniusWebClient | None = None
 
         self._id = f'{name.lower()}_{host.lower().replace('.','')}'
         self.online = True
@@ -169,6 +172,13 @@ class Hub:
                 username=api_username,
                 password=api_password or "",
                 token=api_token,
+            )
+        if tech_token:
+            from .const import TECHNICIAN_USERNAME
+            self._tech_webclient = FroniusWebClient(
+                host=host,
+                username=TECHNICIAN_USERNAME,
+                token=tech_token,
             )
         self._scan_interval = timedelta(seconds=scan_interval)
         self.coordinator = None
@@ -560,6 +570,18 @@ class Hub:
                 data={"entry_id": self._config_entry.entry_id},
             )
 
+    async def _async_tech_web_job(self, func, *args):
+        """Run a tech-client job; on auth failure clear only _tech_webclient."""
+        if not self._tech_webclient:
+            return None
+        try:
+            return await self._hass.async_add_executor_job(func, *args)
+        except FroniusWebAuthError as err:
+            _LOGGER.warning("Disabling Fronius technician web API for %s after auth failure: %s", self._host, err)
+            self._tech_webclient = None
+            self.data["export_soft_limit"] = None
+            return None
+
     async def _async_web_job(
         self,
         func,
@@ -708,6 +730,25 @@ class Hub:
             battery_config = await self._async_web_job(self._webclient.get_battery_config)
             if isinstance(battery_config, dict):
                 self._apply_web_battery_config(battery_config)
+
+        if self._tech_webclient:
+            export_limit_config = await self._async_tech_web_job(self._tech_webclient.get_export_limit_config)
+        elif self._webclient:
+            export_limit_config = await self._async_web_job(self._webclient.get_export_limit_config)
+        else:
+            export_limit_config = None
+        _LOGGER.debug("Export limit config from web API: %s", export_limit_config)
+        if isinstance(export_limit_config, dict) and export_limit_config:
+            soft = (
+                export_limit_config.get("exportLimits", {})
+                .get("activePower", {})
+                .get("softLimit", {})
+            )
+            if isinstance(soft, dict):
+                if soft.get("enabled"):
+                    self.data["export_soft_limit"] = soft.get("powerLimit")
+                else:
+                    self.data["export_soft_limit"] = None
 
         await self._async_sync_solar_api_warning()
 
@@ -938,6 +979,10 @@ class Hub:
         return self._webclient is not None
 
     @property
+    def tech_configured(self) -> bool:
+        return self._tech_webclient is not None
+
+    @property
     def meter_configured(self):
         return self._client.meter_configured
 
@@ -1139,3 +1184,12 @@ class Hub:
 
     async def set_conn_status(self, enable):
         await self._client.set_conn_status(enable)
+
+    async def set_export_soft_limit(self, value: float) -> None:
+        if not self._tech_webclient:
+            raise RuntimeError("Technician credentials not configured — enter the technician password via Configure")
+        await self._async_tech_web_job(
+            self._tech_webclient.set_export_soft_limit,
+            int(round(value)),
+        )
+        self.data["export_soft_limit"] = int(round(value))

--- a/custom_components/fronius_modbus/number.py
+++ b/custom_components/fronius_modbus/number.py
@@ -4,6 +4,7 @@ from .const import (
     STORAGE_API_NUMBER_TYPES,
     STORAGE_MODBUS_NUMBER_TYPES,
     INVERTER_NUMBER_TYPES,
+    INVERTER_WEB_NUMBER_TYPES,
 )
 
 from homeassistant.components.number import (
@@ -87,6 +88,30 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
         )
         entities.append(number)
 
+    if hub.web_api_configured:
+        for number_info in INVERTER_WEB_NUMBER_TYPES:
+            max_val = number_info[2]['max']
+            max_key = number_info[2].get('max_key')
+            if max_key is not None:
+                dynamic_max = hub.data.get(max_key)
+                if isinstance(dynamic_max, (int, float)) and dynamic_max > 0:
+                    max_val = dynamic_max
+
+            number = FroniusModbusNumber(
+                coordinator=coordinator,
+                device_info=hub.device_info_inverter,
+                name=number_info[0],
+                key=number_info[1],
+                translation_key=number_info[0],
+                min_val=number_info[2]['min'],
+                max_val=max_val,
+                unit=number_info[2]['unit'],
+                mode=number_info[2]['mode'],
+                native_step=number_info[2]['step'],
+                hub=hub,
+            )
+            entities.append(number)
+
     async_add_entities(entities)
     return True
 
@@ -156,6 +181,8 @@ class FroniusModbusNumber(FroniusModbusBaseEntity, NumberEntity):
             await self._hub.set_api_battery_power(value)
         elif self._key == 'soc_maximum':
             await self._hub.set_api_soc_values(soc_max=int(round(value)))
+        elif self._key == 'export_soft_limit':
+            await self._hub.set_export_soft_limit(value)
 
         self.async_write_ha_state()
 
@@ -189,4 +216,6 @@ class FroniusModbusNumber(FroniusModbusBaseEntity, NumberEntity):
                 self._hub.web_api_configured
                 and data.get('api_battery_mode_effective_raw') == 1
             )
+        if self._key == 'export_soft_limit':
+            return self._hub.web_api_configured
         return False

--- a/custom_components/fronius_modbus/translations/en.json
+++ b/custom_components/fronius_modbus/translations/en.json
@@ -15,7 +15,11 @@
         "title": "Customer Password",
         "description": "Enter the customer password to create or refresh the stored token. The password is not stored in the config entry.",
         "data": {
-          "api_password": "Customer password"
+          "api_password": "Customer password",
+          "technician_password": "Technician password (optional)"
+        },
+        "data_description": {
+          "technician_password": "Required to enable the Export Limit Control (Soft Limit) setter. Leave empty to skip."
         }
       },
       "reconfigure": {
@@ -31,7 +35,11 @@
         "title": "Customer Password",
         "description": "Enter the customer password to create or refresh the stored token.",
         "data": {
-          "api_password": "Customer password"
+          "api_password": "Customer password",
+          "technician_password": "Technician password (optional)"
+        },
+        "data_description": {
+          "technician_password": "Required to enable the Export Limit Control (Soft Limit) setter. Leave empty to skip."
         }
       }
     },
@@ -84,6 +92,9 @@
       },
       "power_factor": {
         "name": "Power factor"
+      },
+      "export_soft_limit": {
+        "name": "Export soft limit"
       }
     },
     "select": {
@@ -297,6 +308,9 @@
       },
       "ac_limit_rate": {
         "name": "AC limit rate"
+      },
+      "export_soft_limit": {
+        "name": "Export soft limit"
       },
       "ac_limit_enable": {
         "name": "AC limit enabled",
@@ -563,7 +577,11 @@
         "title": "Customer Password",
         "description": "Enter the customer password to create or refresh the stored token.",
         "data": {
-          "api_password": "Customer password"
+          "api_password": "Customer password",
+          "technician_password": "Technician password (optional)"
+        },
+        "data_description": {
+          "technician_password": "Required to enable the Export Limit Control (Soft Limit) setter. Leave empty to skip."
         }
       }
     },


### PR DESCRIPTION
This PR adds support for the Export to Grid (soft limit) setting. 

This setting is only available if you have the technician password for the Inverter. 

Since modbus does not support changing this setting, the setting is changed using the local web API of the inverter.
You need to enable Communication -> Solar API for this to work.

Tested with Fronius Symo GEN24 10.0 Plus.
