### PR TITLE
Fix ImportError for unpack_bitstring with newer pymodbus versions

### DIFF
--- a/custom_components/fronius_modbus/extmodbusclient.py
+++ b/custom_components/fronius_modbus/extmodbusclient.py
@@ -8,11 +8,18 @@ import asyncio
 
 from pymodbus.client import AsyncModbusTcpClient
 try:
-    # For newer pymodbus versions (3.9.x+)
     from pymodbus.pdu.pdu import unpack_bitstring
 except ImportError:
-    # For older pymodbus versions (3.8.x and below)
-    from pymodbus.utilities import unpack_bitstring
+    try:
+        from pymodbus.utilities import unpack_bitstring
+    except ImportError:
+        def unpack_bitstring(data: bytes) -> list[bool]:
+            result = []
+            for byte in data:
+                for i in range(8):
+                    result.append(bool(byte & (1 << i)))
+            return result
+
 from pymodbus.exceptions import ModbusIOException, ConnectionException
 from pymodbus import ExceptionResponse
 


### PR DESCRIPTION
## Problem
Setup fails on Home Assistant 2026.7.0 with:
```
ImportError: cannot import name 'unpack_bitstring' from 'pymodbus.utilities'
```

`unpack_bitstring` was removed from pymodbus starting with version 3.11, breaking both existing import fallback paths (`pymodbus.pdu.pdu` and `pymodbus.utilities`).

## Fix
Added a third fallback: a local implementation of `unpack_bitstring` used when neither pymodbus import path is available.

## Testing
Verified integration loads and Modbus reads work on pymodbus 3.11+.