### PR TITLE
Improve pymodbus compatibility across HA versions

### DIFF
--- a/custom_components/fronius_modbus/extmodbusclient.py
+++ b/custom_components/fronius_modbus/extmodbusclient.py
@@ -221,7 +221,7 @@ class ExtModbusClient:
                 registers.reverse()
             for x in registers:
                 byte_list.extend(int.to_bytes(x, 2, "big"))
-            if data_type == cls.DATATYPE.STRING:
+            if getattr(data_type, "name", None) == "STRING":
                 trailing_nulls_begin = len(byte_list)
                 while trailing_nulls_begin > 0 and not byte_list[trailing_nulls_begin - 1]:
                     trailing_nulls_begin -= 1

--- a/custom_components/fronius_modbus/extmodbusclient.py
+++ b/custom_components/fronius_modbus/extmodbusclient.py
@@ -67,6 +67,11 @@ class ExtModbusClient:
         return self._client.connected
 
     async def _read_holding_registers_compat(self, address: int, count: int, unit_id: int):
+        """Read registers using the device-address keyword supported by pymodbus.
+
+        pymodbus 3.10+ uses ``device_id``, versions 3.8 and 3.9 use
+        ``slave``, and older versions use ``unit``.
+        """
         try:
             return await self._client.read_holding_registers(address=address, count=count, device_id=unit_id)
         except TypeError as err:
@@ -82,6 +87,11 @@ class ExtModbusClient:
         return await self._client.read_holding_registers(address=address, count=count, unit=unit_id)
 
     async def _write_registers_compat(self, address: int, payload: list[int], unit_id: int):
+        """Write registers using the device-address keyword supported by pymodbus.
+
+        pymodbus 3.10+ uses ``device_id``, versions 3.8 and 3.9 use
+        ``slave``, and older versions use ``unit``.
+        """
         try:
             return await self._client.write_registers(address=address, values=payload, device_id=unit_id)
         except TypeError as err:

--- a/custom_components/fronius_modbus/extmodbusclient.py
+++ b/custom_components/fronius_modbus/extmodbusclient.py
@@ -7,16 +7,16 @@ import struct
 import asyncio
 
 from pymodbus.client import AsyncModbusTcpClient
-try:
-    # For newer pymodbus versions (3.9.x+)
-    from pymodbus.pdu.pdu import unpack_bitstring
-except ImportError:
-    # For older pymodbus versions (3.8.x and below)
-    from pymodbus.utilities import unpack_bitstring
 from pymodbus.exceptions import ModbusIOException, ConnectionException
 from pymodbus import ExceptionResponse
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def unpack_bitstring(data: bytes | bytearray) -> list[bool]:
+    """Return pymodbus-compatible LSB-first bit values for each byte."""
+    return [bool(byte & (1 << bit)) for byte in data for bit in range(8)]
+
 
 class ExtModbusClient:
 
@@ -66,6 +66,36 @@ class ExtModbusClient:
     def connected(self) -> bool:
         return self._client.connected
 
+    async def _read_holding_registers_compat(self, address: int, count: int, unit_id: int):
+        try:
+            return await self._client.read_holding_registers(address=address, count=count, device_id=unit_id)
+        except TypeError as err:
+            if "device_id" not in str(err):
+                raise
+
+        try:
+            return await self._client.read_holding_registers(address=address, count=count, slave=unit_id)
+        except TypeError as err:
+            if "slave" not in str(err):
+                raise
+
+        return await self._client.read_holding_registers(address=address, count=count, unit=unit_id)
+
+    async def _write_registers_compat(self, address: int, payload: list[int], unit_id: int):
+        try:
+            return await self._client.write_registers(address=address, values=payload, device_id=unit_id)
+        except TypeError as err:
+            if "device_id" not in str(err):
+                raise
+
+        try:
+            return await self._client.write_registers(address=address, values=payload, slave=unit_id)
+        except TypeError as err:
+            if "slave" not in str(err):
+                raise
+
+        return await self._client.write_registers(address=address, values=payload, unit=unit_id)
+
     def validate(self, value, comparison, against):
         ops = {
             ">": operator.gt,
@@ -85,7 +115,7 @@ class ExtModbusClient:
         for attempt in range(retries+1):
             await self._check_and_reconnect()
             try:
-                data = await self._client.read_holding_registers(address=address, count=count, device_id=unit_id)
+                data = await self._read_holding_registers_compat(address=address, count=count, unit_id=unit_id)
             except ModbusIOException as e:
                 self._close_after_transport_error()
                 _LOGGER.debug(f'error reading registers. IO error retries: {attempt}/{retries} connected: {self._client.connected} address: {address} count: {count} unit id: {unit_id} error: {e}')
@@ -142,7 +172,7 @@ class ExtModbusClient:
         await self._check_and_reconnect()
 
         try:
-            result = await self._client.write_registers(address=address, values=payload, device_id=unit_id)
+            result = await self._write_registers_compat(address=address, payload=payload, unit_id=unit_id)
         except ModbusIOException as e:
             self._close_after_transport_error()
             raise Exception(f'write_registers: IO error {self._client.connected} {e.fcode} {e}')
@@ -187,6 +217,7 @@ class ExtModbusClient:
         if not (data_len := data_type.value[1]):
             byte_list = bytearray()
             if word_order == "little":
+                registers = list(registers)
                 registers.reverse()
             for x in registers:
                 byte_list.extend(int.to_bytes(x, 2, "big"))
@@ -206,6 +237,7 @@ class ExtModbusClient:
         for i in range(0, reg_len, data_len):
             regs = registers[i:i+data_len]
             if word_order == "little":
+                regs = list(regs)
                 regs.reverse()
             byte_list = bytearray()
             for x in regs:
@@ -282,4 +314,4 @@ class ExtModbusClient:
         return False
 
     def get_string_from_registers(self, regs):
-        return self.strip_escapes(self._client.convert_from_registers(regs, data_type = self._client.DATATYPE.STRING))
+        return self.strip_escapes(self.convert_from_registers(regs, data_type = self._client.DATATYPE.STRING))

--- a/custom_components/fronius_modbus/hub.py
+++ b/custom_components/fronius_modbus/hub.py
@@ -1035,7 +1035,7 @@ class Hub:
             if current < required:
                 raise Exception(f"pymodbus {current_version} found, please update to {self.PYMODBUS_VERSION} or higher")
             elif current > required:
-                _LOGGER.warning(f"newer pymodbus {current_version} found")
+                _LOGGER.info(f"newer pymodbus {current_version} found")
             _LOGGER.debug(f"pymodbus {current_version}")
         except Exception as e:
             _LOGGER.error(f"Error checking pymodbus version: {e}")


### PR DESCRIPTION
```markdown
## Summary

This PR improves compatibility with newer `pymodbus` versions used by Home Assistant and fixes setup failures seen after upgrading to Home Assistant Core 2026.7.0 / `pymodbus 3.13.1`.

## Changes

- Replace the unstable `pymodbus` import of `unpack_bitstring` with a local LSB-first implementation.
- Add compatibility wrappers for Modbus register reads/writes:
  - use `device_id=` for `pymodbus >= 3.10`
  - fall back to `slave=` for `pymodbus 3.8/3.9`
  - fall back to `unit=` for older call signatures
- Fix local register conversion so it works when called through subclasses such as `FroniusModbusClient`.
- Avoid mutating caller-provided register lists when using `word_order="little"`.
- Use the local register conversion helper for string decoding.
- Downgrade the “newer pymodbus found” message from warning to info, since the manifest allows newer versions.

## Why

Home Assistant Core 2026.7.0 ships with `pymodbus 3.13.1`. In that version, `unpack_bitstring` is no longer available from the internal import paths used by this integration, causing setup to fail during import.

`pymodbus` also changed Modbus device addressing from `slave=` to `device_id=` in 3.10, so the integration now handles both APIs.

After the initial import fix, setup could still fail while reading device info because the local conversion helper compared against `cls.DATATYPE.STRING`. When called through `FroniusModbusClient`, `cls` has no `DATATYPE` attribute. This PR fixes that by checking the passed datatype enum itself.

## Validation

Tested successfully with:

- `pymodbus 3.8.6`
- `pymodbus 3.10.0`
- `pymodbus 3.13.1`

Also verified with:

- Python compile checks for the integration package
- Direct Modbus read against a real Fronius GEN24 on `pymodbus 3.13.1`
- Full `FroniusModbusClient.init_data()` against a real device, confirming inverter, meter, SunSpec, MPPT, and storage discovery
```